### PR TITLE
Only set SimulatorFilter on module logger.

### DIFF
--- a/sample_scripts/good.py
+++ b/sample_scripts/good.py
@@ -18,9 +18,25 @@ class SimulatorFilter(logging.Filter):
 
 
 def setup_logging(log_level, simulate):
-    f = '%(asctime)s | %(prefix)s%(filename)s | %(levelname)s | %(message)s'
-    logging.basicConfig(format=f, level=log_level)
+
+    # Setup a root logger with a format that matches what we plan to use.
+    # This means LogRecords from other libraries will still be emitted and will
+    # look similar to ours.
+    root_format_string = '%(asctime)s | %(levelname)s | %(name)s | %(message)s'
+    logging.basicConfig(format=root_format_string, level=log_level)
+
+    # Setup our logger with a filter that adds a prefix whenever simulate=True.
+    # Don't propagate because our format string expects a prefix not set on
+    # handlers of loggers created by other libraries.
+    format_string = '%(asctime)s | %(levelname)s | %(name)s | %(prefix)s%(message)s' # noqa
     logger = logging.getLogger(__name__)
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter(fmt=format_string)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(log_level)
+    logger = logging.getLogger(__name__)
+    logger.propagate = False
     has_simulator_filter = [i for i in logger.filters
                             if isinstance(i, SimulatorFilter)]
     if not has_simulator_filter:


### PR DESCRIPTION
Fixes #4.

Tox passes. Tried this out with some sample boto3 code and both our logs and boto's logs were emitted without errors. Our logs showed the simulator prefix in simulate mode but boto's didn't (which is what we want because nothing was telling boto to simulate, it was really acting).