### PR TITLE
Remove Python 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ pip-installability it's entirely reasonable to remove it:
 
 ## Development
 
-The tests run against Python 2.7 and Python 3.6, so you'll need both installed to run the tests. Check out
-[pyenv][pyenv] for an easy way.
+The tests run against several Python versions. Check out [pyenv][pyenv] for an easy way to install them all.
 
-As always, you should use a [venv][venv] (Python 3) or a [virtualenv][virtualenv] (Python 2).
+As always, you should use a [venv][venv].
 
 1. Use pip's editable mode and install the `testing` extras:
 
@@ -63,7 +62,7 @@ Check out the [contributing guide](CONTRIBUTING.md)!
 
 ## Production
 
-One great approach for Python 3 is this:
+Here's an approach I like:
 
 1. Build a [wheel][wheel].
 

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ Here's an approach I like:
 1. Distribute the wheel file from the `dist` folder:
 
    ```shell
-   dist/python_production_script_recipe-0.2.0-py3-none-any.whl
+   dist/python_production_script_recipe-1.0.0-py3-none-any.whl
    ```
 
 1. Install the wheel with pip.
 
    ```shell
-   pip install python_production_script_recipe-0.2.0-py3-none-any.whl
+   pip install python_production_script_recipe-1.0.0-py3-none-any.whl
    ```
 
 1. Run the script with its console script:

--- a/sample_scripts/good.py
+++ b/sample_scripts/good.py
@@ -72,9 +72,11 @@ def act_on_offset(offset, simulate=False):
             done = True
             logger.info('Action complete.')
         except Exception:
+            # Catching all exceptions is an anti-pattern. This is a generic
+            # example of how you could use log levels when errors happen.
             # Our pretend work won't trigger this, but a real script would do
             # something more interesting that might break.
-            logger.info('Failure.')
+            logger.error('Failure.')
     else:
         logger.debug('Simulate option set. Not acting.')
     return done

--- a/sample_scripts/good.py
+++ b/sample_scripts/good.py
@@ -75,6 +75,8 @@ def act_on_offset(offset, simulate=False):
             # Our pretend work won't trigger this, but a real script would do
             # something more interesting that might break.
             logger.info('Failure.')
+    else:
+        logger.debug('Simulate option set. Not acting.')
     return done
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,13 @@
 from setuptools import setup
-import sys
 
 testing_requirements = [
     'pytest-cov==2.5.1',
     'tox==2.7.0',
 ]
 
-if sys.version_info[0] < 3:
-    # In Python 2 `mock` was a third-party library.
-    testing_requirements.append('mock==2.0.0')
-
 setup(
     name='python_production_script_recipe',
-    version='0.2.0',
+    version='1.0.0',
     author='Adam Burns',
     author_email='adam@operatingops.org',
     description='Recipe of best practices for Python scripts in production.',

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from setuptools import setup
 
 testing_requirements = [
-    'pytest-cov==2.5.1',
-    'tox==2.7.0',
+    'pytest-cov >=2.7, <2.8',
+    'tox >=3.13, <3.14',
 ]
 
 setup(

--- a/tests/test_sample_script_good.py
+++ b/tests/test_sample_script_good.py
@@ -1,7 +1,4 @@
-try:
-    import mock  # Python 2.
-except ImportError:
-    from unittest import mock  # Python 3.
+from unittest import mock
 
 from sample_scripts import good
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 exclude = .tox
 
 [tox]
-envlist = py27,py36
+envlist = py36,py37
 
 [testenv]
 deps = flake8


### PR DESCRIPTION
Fixes #7 

Because this is backwards-incompatible, I bumped the major version. Previously, this was an unstable 0.x.y version, but the project has been live long enough that it's time to go stable. I bumped to 1.0.0.

I bumped the versions of testing deps and adjusted the version specs to allow installing the latest patch release at runtime. It was a convenient time.

I also did a little cleanup of the error handling part of the example script that I discovered while I was exercising my changes.

Tox passes in all currently-supported Python versions.