### PR TITLE
Simpler logging

### DIFF
--- a/sample_scripts/good.py
+++ b/sample_scripts/good.py
@@ -9,8 +9,10 @@ import time
 from pythonjsonlogger import jsonlogger
 
 
+logger = logging.getLogger(__name__)
+
+
 def setup_logging(log_level, simulate):
-    logger = logging.getLogger(__name__)
     logger.setLevel(log_level)
     json_handler = logging.StreamHandler()
     if simulate:
@@ -47,7 +49,6 @@ def offset_is_actionable(offset):
 
 
 def act_on_offset(offset, simulate=False):
-    logger = logging.getLogger(__name__)
     done = False
     if not simulate:
         try:
@@ -64,7 +65,6 @@ def act_on_offset(offset, simulate=False):
 
 def run(offset, log_level='INFO', simulate=False):
     setup_logging(log_level, simulate)
-    logger = logging.getLogger(__name__)
     if offset_is_actionable(offset):
         logger.info('Acting.')
         act_on_offset(offset, simulate)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [
 
 testing_requirements = [
     'pytest-cov >=2.7, <2.8',
-    'tox >=3.13, <3.14',
+    'tox >=3, <4',
 ]
 
 setup(


### PR DESCRIPTION
Call `getLogger()` in module instead of functions.

This is a simpler approach inspired by the Python [core docs on advanced logging](https://docs.python.org/3/howto/logging.html#advanced-logging-tutorial):

"A good convention to use when naming loggers is to use a module-level logger"

This includes a loosening of the tox version specification. I got errors running the tests and upgrading fixed them.

Tests all pass. Running the sample script manually still works as expected.